### PR TITLE
Replace libressl with openssl

### DIFF
--- a/env/aarch64
+++ b/env/aarch64
@@ -164,6 +164,12 @@ PKGVERS_BRANCH=$(date +%Y.%-m.%-e.%-H.%-M);	export PKGVERS_BRANCH
 #export PYTHON3_VERSION=3.5
 #export PYTHON3_PKGVERS=-35
 #export PYTHON3_SUFFIX=m
+for v in 3.9 3.10 3.11; do
+	[ -x /usr/bin/python$v ] || continue
+	export PYTHON3_VERSION=$v
+	export PYTHON3_PKGVERS=-${v//./}
+	break
+done
 
 # Set console color scheme either by build type:
 #

--- a/files/openssl-15-illumos-aarch.conf
+++ b/files/openssl-15-illumos-aarch.conf
@@ -1,0 +1,17 @@
+my %targets = (
+    "solaris-aarch64-gcc" => {
+        inherit_from     => [ "solaris-common-gcc" ],
+        CC               => "aarch64-solaris2.11-gcc",
+        CFLAGS           => add_before(picker(default => "-Wall",
+                                              debug   => "-O0 -g",
+                                              release => "-O3")),
+        cflags           => add_before("-mno-outline-atomics -fpic", threads("-pthread")),
+        lib_cppflags     => add("-DL_ENDIAN"),
+        ex_libs          => combine("-lz -lsocket -lnsl", threads("-pthread")),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        asm_arch         => 'aarch64',
+        perlasm_scheme   => "elf",
+        shared_cflag     => "-fpic -mno-outline-atomics",
+        shared_ldflag    => add_before("-shared"),
+    },
+);


### PR DESCRIPTION
Replace libressl with openssl. It needs `gtar` to unpack, or at least to unpack cleanly, so that's a new implicit dependency we might not want (`gtar` must be in path). I've done a full download/setup/illumos build with this in an omnios r44 zone.