### PR TITLE
native x86 build fixes

### DIFF
--- a/env/aarch64
+++ b/env/aarch64
@@ -179,7 +179,9 @@ for v in 3.9 3.10 3.11; do
 done
 
 # Skip Java 11 builds on distributions that don't support it
-if [[ $(readlink -e "/usr/java") == "/usr/jdk/instances/openjdk11.0" ]]; then
+if [[ -d "/usr/jdk/instances/openjdk11.0" ]]; then
+	export JAVA_HOME=/usr/jdk/instances/openjdk11.0
+	export JAVA_ROOT=/usr/jdk/instances/openjdk11.0
 	export BLD_JAVA_11=
 fi
 

--- a/env/aarch64
+++ b/env/aarch64
@@ -81,10 +81,10 @@ export CODEMGR_WS="`git rev-parse --show-toplevel`"
 #
 
 # OmniOS, etc.
-if [[ -d /opt/gcc-7 ]]; then
+if [[ -d /opt/gcc-10 ]]; then
 	export i386_GNUC_ROOT=/opt/gcc-10
 # OpenIndiana etc.
-elif [[ -d /usr/gcc/7 ]]; then
+elif [[ -d /usr/gcc/10 ]]; then
 	export i386_GNUC_ROOT=/usr/gcc/10
 else
 	print -u2 "I can't work out where your native GCC 10 is!"
@@ -95,7 +95,7 @@ fi
 if [[ -d /opt/gcc-7 ]]; then
 	export i386_GNUC_7_ROOT=/opt/gcc-7
 # OpenIndiana etc.
-elif [[ -d /usr/gcc/10 ]]; then
+elif [[ -d /usr/gcc/7 ]]; then
 	export i386_GNUC_7_ROOT=/usr/gcc/7
 else
 	print -u2 "I can't work out where your native GCC 7 is!"


### PR DESCRIPTION
This PR changes the primary compiler to GCC 10 for native x86 builds, additionally it fixes the build when the openjdk version mediator is not set to 11. E.g.:
```
hadfl@nemesis:~$ pkg mediator openjdk
MEDIATOR   VER. SRC. VERSION IMPL. SRC. IMPLEMENTATION
openjdk    system    17      system
hadfl@nemesis:~$ readlink -e /usr/java
/usr/jdk/instances/openjdk17.0
```

mail_msg:
```
==== Nightly build started:   Mon Apr 17 12:54:45 UTC 2023 ====
==== Nightly build completed: Mon Apr 17 13:24:59 UTC 2023 ====

==== Total build time ====

real    0:30:14

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-5fb4290b24b i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 34

cw version 9.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151045/10.4.0-il-1) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151045/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/jdk/instances/openjdk11.0/bin/javac
openjdk full version "11.0.18+10-omnios-151045"

/usr/bin/openssl
OpenSSL 3.0.8 7 Feb 2023 (Library: OpenSSL 3.0.8 7 Feb 2023)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1788 (illumos)

Build project:  default
Build taskid:   225

==== Nightly argument issues ====


==== Build version ====

arm64-gate-0-g842125f927

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (i386/DEBUG) ====


==== Build warnings (i386/DEBUG) ====


==== Elapsed build time (i386/DEBUG) ====

real    21:56.3
user  7:09:16.1
sys   1:04:54.2

==== Build noise differences (i386/DEBUG) ====


==== package build errors (i386/DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Nightly build status ====

Completed successfully
```