### PR TITLE
env: enable smatch if we're not doing a cross-build

### DIFF
--- a/env/aarch64
+++ b/env/aarch64
@@ -123,8 +123,9 @@ if [[ ${MACH} == "aarch64" ]]; then
 fi
 
 # XXXARM: No cross, very broken
-# comment to disable smatch
-#export ENABLE_SMATCH=1
+if [[ ${MACH} == ${NATIVE_MACH} ]]; then
+	export ENABLE_SMATCH=1
+fi
 
 ONNV_BUILDNUM=$(date +%Y%m%d%H%M);		export ONNV_BUILDNUM
 PKGVERS_BRANCH=999999.$(date +%Y.%-m.%-e.%-H.%-M);	export PKGVERS_BRANCH


### PR DESCRIPTION
This effectively re-enables smatch when doing i386 builds of the illumos arm64-gate branch, which allows us to be sure we're not making common code any worse.