### PR TITLE
Build a raspberry pi 4 image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 src/
 reference/
 stamps/
+out/
 
 **/.make.state
 **/*.o
@@ -15,4 +16,5 @@ stamps/
 
 qemu-setup/illumos-disk.img
 qemu-setup/inetboot.bin
+rpi4-setup/
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,19 +3,9 @@ illumos-gate/
 arm-docs/
 archives/
 build/
+src/
 reference/
 stamps/
-perl-5.36.0/
-perl-cross-1.4/
-dtc-1.6.1/
-
-illumos-gate/
-gcc/
-binutils-gdb/
-u-boot/
-
-cross/
-sysroot/
 
 **/.make.state
 **/*.o
@@ -25,3 +15,4 @@ sysroot/
 
 qemu-setup/illumos-disk.img
 qemu-setup/inetboot.bin
+

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-# An AArch64 sysroot to the degree we need one
-SYSROOT=$(PWD)/sysroot
-
-# The area where our cross tools land
-CROSS=$(PWD)/cross
+# The directory where downloaded source is extracted
+SRCS=$(PWD)/src
 
 # The directory where build output lands for extra bits
 BUILDS=$(PWD)/build
+#
+# The area where our cross tools land
+CROSS=$(BUILDS)/cross
+
+# An AArch64 sysroot to the degree we need one
+SYSROOT=$(BUILDS)/sysroot
 
 # The directory where we mark things as built, because we're lazy
 STAMPS=$(PWD)/stamps
@@ -24,7 +27,18 @@ GMPINCDIR= /usr/include/gmp
 
 # XXXARM: We can't .KEEP_STATE because something confuses everything
 # (directory changes in rules?) and it gets bogus dependencies and always
-# rebuilds everything (which, to be fair, often happens anyway).
+# rebuilds everything.
+
+all:
+	@echo "Targets:"
+	@echo
+	@echo "    download - fetch required sources"
+	@echo "       setup - build all pre-requisites"
+	@echo "     illumos - build illumos"
+	@echo "        disk - build QEMU disk image"
+	@echo
+	@echo "These are usually run one at a time, in the order shown above."
+	@echo "See README.md for more information."
 
 SETUP_TARGETS =		\
 	binutils-gdb 	\
@@ -65,31 +79,41 @@ DOWNLOADS=			\
 	perl			\
 	u-boot
 
-download-perl: $(ARCHIVES)
-	wget -O archives/perl-5.36.0.tar.gz https://www.cpan.org/src/5.0/perl-5.36.0.tar.gz
-	tar xf archives/perl-5.36.0.tar.gz
-	wget -O archives/perl-cross-1.4.tar.gz https://github.com/arsv/perl-cross/releases/download/1.4/perl-cross-1.4.tar.gz
-	tar xf archives/perl-cross-1.4.tar.gz
-	rsync -a perl-cross-1.4/* perl-5.36.0/
-	(cd perl-5.36.0 && patch -p1 < ../patches/perl-nanosleep.patch)
+PERLVER=5.36.0
+PERLCROSSVER=1.4
+download-perl: $(ARCHIVES) $(SRCS)
+	wget -O $(ARCHIVES)/perl-$(PERLVER).tar.gz \
+	    https://www.cpan.org/src/5.0/perl-$(PERLVER).tar.gz
+	tar xf archives/perl-$(PERLVER).tar.gz -C $(SRCS)
+	wget -O $(ARCHIVES)/perl-cross-$(PERLCROSSVER).tar.gz \
+	    https://github.com/arsv/perl-cross/releases/download/$(PERLCROSSVER)/perl-cross-$(PERLCROSSVER).tar.gz
+	tar xf $(ARCHIVES)/perl-cross-$(PERLCROSSVER).tar.gz -C $(SRCS)
+	rsync -a $(SRCS)/perl-cross-$(PERLCROSSVER)/* $(SRCS)/perl-$(PERLVER)/
+	cd $(SRCS)/perl-$(PERLVER) && \
+	    patch -p1 < $(PWD)/patches/perl-nanosleep.patch
 
-download-gcc: $(ARCHIVES)
-	git clone --shallow-since=2019-01-01 -b il-10_4_0-arm64 https://github.com/richlowe/gcc
+download-gcc: $(SRCS)
+	git clone --shallow-since=2019-01-01 -b il-10_4_0-arm64 \
+	    https://github.com/richlowe/gcc $(SRCS)/gcc
 
-download-binutils-gdb: $(ARCHIVES)
-	git clone --shallow-since=2019-01-01 -b illumos-arm64 https://github.com/richlowe/binutils-gdb
+download-binutils-gdb: $(SRCS)
+	git clone --shallow-since=2019-01-01 -b illumos-arm64 \
+	    https://github.com/richlowe/binutils-gdb $(SRCS)/binutils-gdb
 
-download-illumos-gate: $(ARCHIVES)
+download-illumos-gate: FRC
 	git clone -b arm64-gate https://github.com/richlowe/illumos-gate
 
-download-u-boot: $(ARCHIVES)
-	git clone --shallow-since=2019-01-01 -b v2022.10 https://github.com/u-boot/u-boot/
+download-u-boot: $(SRCS)
+	git clone --shallow-since=2019-01-01 -b v2022.10 \
+	    https://github.com/u-boot/u-boot $(SRCS)/u-boot
 
 # XXXARM: We specify what we extract, because the release tarball contains a
 # GNU tar-ism we don't understand.
+DTCVER=1.6.1
 download-dtc: $(ARCHIVES)
-	wget -O archives/dtc-1.6.1.tar.gz https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/dtc-1.6.1.tar.gz
-	tar xf archives/dtc-1.6.1.tar.gz dtc-1.6.1
+	wget -O $(ARCHIVES)/dtc-$(DTCVER).tar.gz \
+	    https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/dtc-$(DTCVER).tar.gz
+	tar xf $(ARCHIVES)/dtc-$(DTCVER).tar.gz dtc-$(DTCVER) -C $(SRCS)
 
 $(ARCHIVES)/$(SYSROOT_PUBLISHER): $(ARCHIVES)
 	pkgrepo -s $@ create
@@ -98,24 +122,27 @@ download-$(SYSROOT_PUBLISHER): $(ARCHIVES)/$(SYSROOT_PUBLISHER)
 	pkgrecv -s $(SYSROOT_REPO) -m latest -d $^ '*@latest'
 
 download: $(DOWNLOADS:%=download-%)
-setup: $(SETUP_TARGETS)
-$(SETUP_TARGETS): $(SETUP_TARGETS:%=$(BUILDS)/%) $(SYSROOT) $(CROSS) $(BUILDS) $(STAMPS)
 
-sysroot: $(SYSROOT)
-$(SYSROOT): FRC
-	[ -f $@/var/pkg/pkg5.image ] || pkg image-create -f --zone \
+
+setup: $(SETUP_TARGETS:%=$(STAMPS)/%-stamp)
+$(SETUP_TARGETS:%=$(STAMPS)/%-stamp): $(BUILDS) $(STAMPS)
+
+sysroot: $(STAMPS)/sysroot-stamp
+$(STAMPS)/sysroot-stamp:
+	pkg image-create -f --zone \
 	    --publisher $(SYSROOT_PUBLISHER)=$(ARCHIVES)/$(SYSROOT_PUBLISHER) \
 	    --variant variant.arch=aarch64 \
 	    --facet osnet-lock=false \
 	    --facet doc.man=false \
-	    $@
-	-pkg -R $@ install $(SYSROOT_PKGS)
-
+	    $(SYSROOT) && \
+	pkg -R $(SYSROOT) install $(SYSROOT_PKGS) && \
+	touch $@
 
 binutils-gdb: $(STAMPS)/binutils-gdb-stamp
-$(STAMPS)/binutils-gdb-stamp: sysroot
+$(STAMPS)/binutils-gdb-stamp: $(STAMPS)/sysroot-stamp
+	mkdir -p $(BUILDS)/binutils-gdb && \
 	(cd $(BUILDS)/binutils-gdb && \
-	../../binutils-gdb/configure \
+	$(SRCS)/binutils-gdb/configure \
 	    --with-sysroot \
 	    --target=aarch64-unknown-solaris2.11 \
 	    --prefix=$(CROSS) \
@@ -124,9 +151,10 @@ $(STAMPS)/binutils-gdb-stamp: sysroot
 	gmake -j $(MAX_JOBS) install) && \
 	touch $@
 
-# Build a tools ld and headers and copy them into the sysroot (in the normal place)
+# Build a tools ld and headers and copy them into the sysroot (in the normal
+# place)
 sgs: $(STAMPS)/sgs-stamp
-$(STAMPS)/sgs-stamp: sysroot
+$(STAMPS)/sgs-stamp: $(STAMPS)/sysroot-stamp
 	(cd illumos-gate && \
 	 $(BLDENV) -T aarch64 ../env/aarch64 'cd usr/src/; make -j $(MAX_JOBS) bldtools sgs' && \
 	 rsync -a usr/src/tools/proto/root_i386-nd/ $(CROSS)/ && \
@@ -135,72 +163,53 @@ $(STAMPS)/sgs-stamp: sysroot
 	touch $@
 
 # Note lp64 only, the default is multilib
+COMMON_GCC_OPTS= 						\
+	--with-gmp-include=$(GMPINCDIR)				\
+	--target=aarch64-unknown-solaris2.11			\
+	--with-abi=lp64						\
+	--prefix=$(CROSS)					\
+	--enable-languages=c,c++				\
+	--with-build-sysroot=$(SYSROOT)				\
+	--enable-c99						\
+	--disable-libquadmath					\
+	--disable-libmudflag					\
+	--disable-libgomp					\
+	--disable-decimal-float					\
+	--disable-libitm					\
+	--disable-libsanitizer					\
+	--disable-libvtv					\
+	--disable-libcilkcrts					\
+	--with-system-zlib					\
+	--enable-__cxa-atexit					\
+	--enable-initfini-array					\
+	--with-headers=$(SYSROOT)/usr/include			\
+	--with-gnu-as						\
+	--with-as=$(CROSS)/bin/aarch64-unknown-solaris2.11-as	\
+	--without-gnu-ld					\
+	--with-ld=$(CROSS)/opt/onbld/bin/amd64/ld
+
 # This is the bootstrap GCC used to build bootstrap bits we can then use when
 # building a real GCC
 boot-gcc: $(STAMPS)/boot-gcc-stamp
-$(STAMPS)/boot-gcc-stamp: sgs binutils-gdb sysroot
+$(STAMPS)/boot-gcc-stamp: $(STAMPS)/sgs-stamp $(STAMPS)/binutils-gdb-stamp
+	mkdir -p $(BUILDS)/boot-gcc && \
 	(cd $(BUILDS)/boot-gcc; \
-	../../gcc/configure \
-	    --with-gmp-include=$(GMPINCDIR) \
-	    --target=aarch64-unknown-solaris2.11 \
-	    --with-abi=lp64 \
-	    --prefix=$(CROSS) \
-	    --enable-languages=c,c++ \
-	    --with-build-sysroot=$(SYSROOT) \
+	$(SRCS)/gcc/configure $(COMMON_GCC_OPTS) \
 	    --disable-shared \
-	    --enable-c99 \
 	    --disable-libstdcxx \
-	    --disable-libquadmath \
-	    --disable-libmudflag \
-	    --disable-libgomp \
-	    --disable-decimal-float \
-	    --disable-libatomic \
-	    --disable-libitm \
-	    --disable-libsanitizer \
-	    --disable-libvtv \
-	    --disable-libcilkcrts \
-	    --with-system-zlib \
-	    --enable-__cxa-atexit \
-	    --enable-initfini-array \
-	    --with-headers=$(SYSROOT)/usr/include \
-	    --with-gnu-as \
-	    --with-as=$(CROSS)/bin/aarch64-unknown-solaris2.11-as \
-	    --without-gnu-ld \
-	    --with-ld=$(CROSS)/opt/onbld/bin/amd64/ld && \
+	    --disable-libatomic && \
 	gmake -j $(MAX_JOBS) && \
 	gmake -j $(MAX_JOBS) install && \
 	rm -fr $(CROSS)/lib/gcc/aarch64-unknown-solaris2.11/10.4.0/include-fixed) && \
 	touch $@
 
 gcc: $(STAMPS)/gcc-stamp
-$(STAMPS)/gcc-stamp: sgs binutils-gdb boot-gcc sysroot
+$(STAMPS)/gcc-stamp: $(STAMPS)/boot-gcc-stamp
+	mkdir -p $(BUILDS)/gcc && \
 	(cd $(BUILDS)/gcc; \
 	env CFLAGS_FOR_TARGET="-g -O2 -mno-outline-atomics -mtls-dialect=trad" \
 	    CXXFLAGS_FOR_TARGET="-g -O2 -mno-outline-atomics -mtls-dialect=trad" \
-	../../gcc/configure \
-	    --with-gmp-include=$(GMPINCDIR) \
-	    --target=aarch64-unknown-solaris2.11 \
-	    --with-abi=lp64 \
-	    --prefix=$(CROSS) \
-	    --enable-languages=c,c++ \
-	    --with-build-sysroot=$(SYSROOT) \
-	    --enable-c99 \
-	    --disable-libquadmath \
-	    --disable-libmudflag \
-	    --disable-libgomp \
-	    --disable-decimal-float \
-	    --disable-libitm \
-	    --disable-libsanitizer \
-	    --disable-libvtv \
-	    --disable-libcilkcrts \
-	    --with-system-zlib \
-	    --enable-__cxa-atexit \
-	    --enable-initfini-array \
-	    --with-headers=$(SYSROOT)/usr/include \
-	    --with-gnu-as \
-	    --with-as=$(CROSS)/bin/aarch64-unknown-solaris2.11-as \
-	    --without-gnu-ld \
-	    --with-ld=$(CROSS)/opt/onbld/bin/amd64/ld && \
+	$(SRCS)/gcc/configure $(COMMON_GCC_OPTS) && \
 	gmake -j $(MAX_JOBS) && \
 	gmake -j $(MAX_JOBS) install && \
 	rm -fr $(CROSS)/lib/gcc/aarch64-unknown-solaris2.11/10.4.0/include-fixed) && \
@@ -212,8 +221,8 @@ $(STAMPS)/gcc-stamp: sgs binutils-gdb boot-gcc sysroot
 # miniperl is racy (i.e. xconfig.h is not re-generated before the build uses it)
 # configure breaks with certain locale settings
 perl: $(STAMPS)/perl-stamp
-$(STAMPS)/perl-stamp: gcc sysroot
-	(cd perl-5.36.0 && \
+$(STAMPS)/perl-stamp: $(STAMPS)/gcc-stamp
+	(cd $(SRCS)/perl-$(PERLVER) && \
 	env PATH="/usr/gnu/bin:$$PATH" LC_ALL=C.UTF-8 \
 	./configure \
 	    --target=aarch64-unknown-solaris2.11 \
@@ -253,38 +262,39 @@ $(STAMPS)/perl-stamp: gcc sysroot
 	touch $@
 
 u-boot: $(STAMPS)/u-boot-stamp
-$(STAMPS)/u-boot-stamp: sysroot
-	cd u-boot && \
-	gmake V=1 O=$(PWD)/build/u-boot \
+$(STAMPS)/u-boot-stamp: $(STAMPS)/sysroot-stamp
+	mkdir -p $(BUILDS)/u-boot && \
+	gmake -C $(SRCS)/u-boot V=1 O=$(BUILDS)/u-boot \
 	    HOSTCC="gcc -m64" \
 	    HOSTCFLAGS+="-I/opt/ooce/include" \
 	    HOSTLDLIBS+="-L/opt/ooce/lib/amd64 -lnsl -lsocket" \
 	    sandbox_defconfig && \
-	gmake V=1 O=$(PWD)/build/u-boot \
+	gmake -C $(SRCS)/u-boot V=1 O=$(BUILDS)/u-boot \
 	    HOSTCC="gcc -m64" \
 	    HOSTCFLAGS+="-I/opt/ooce/include" \
 	    HOSTLDLIBS+="-L/opt/ooce/lib/amd64 -lnsl -lsocket" tools && \
 	touch $@
 
 dtc: $(STAMPS)/dtc-stamp
-$(STAMPS)/dtc-stamp: sysroot
-	cd dtc-1.6.1 && \
-	gmake NO_YAML=1 \
+$(STAMPS)/dtc-stamp: $(STAMPS)/sysroot-stamp
+	rsync -a $(SRCS)/dtc-$(DTCVER)/ $(BUILDS)/dtc-$(DTCVER)/ && \
+	rm -rf $(BUILDS)/dtc-$(DTCVER)/.git && \
+	gmake -C $(BUILDS)/dtc-$(DTCVER) \
 	    NO_PYTHON=1 \
 	    SHAREDLIB_LDFLAGS="-shared -Wl,-soname" && \
-	gmake PREFIX=$(CROSS) \
+	gmake -C $(BUILDS)/dtc-$(DTCVER) PREFIX=$(CROSS) \
 	    NO_YAML=1 \
 	    NO_PYTHON=1 \
 	    INSTALL=/usr/gnu/bin/install install && \
 	touch $@
 
 illumos: $(STAMPS)/illumos-stamp
-$(STAMPS)/illumos-stamp: setup
+$(STAMPS)/illumos-stamp: $(SETUP_TARGETS:%=$(STAMPS)/%-stamp)
 	(cd illumos-gate && \
 	 $(NIGHTLY) -T aarch64 ../env/aarch64) && \
 	touch $@
 
-disk: illumos
+disk: $(STAMPS)/illumos-stamp
 	ksh tools/build_disk.sh
 
 $(BUILDS):
@@ -293,24 +303,23 @@ $(STAMPS):
 	mkdir -p $@
 $(ARCHIVES):
 	mkdir -p $@
+$(SRCS):
+	mkdir -p $@
 $(CROSS):
 	mkdir -p $@
-$(SETUP_TARGETS:%=$(BUILDS)/%):
-	mkdir -p $@
-
-clean-dtc:
-	cd dtc-1.6.1 && gmake clean
 
 clean-illumos:
 	(cd illumos-gate && \
 	 rm -fr packages && \
 	 rm -fr proto && \
-	 $(BLDENV) -T aarch64 ../env/aarch64 'cd usr/src; make -j $(MAX_JOBS) clobber')
+	 $(BLDENV) -T aarch64 ../env/aarch64 \
+	     'cd usr/src; make -j $(MAX_JOBS) clobber') && \
+	 rm -f $(STAMPS)/illumos-stamp
 
-clean: clean-dtc clean-illumos
-	rm -fr $(SYSROOT) $(BUILDS) $(STAMPS) $(CROSS)
+clean: clean-illumos
+	rm -fr $(BUILDS) $(STAMPS)
 
-clobber: clean
-	rm -fr $(ARCHIVES)
+clobber:
+	rm -fr $(BUILDS) $(STAMPS) $(ARCHIVES) $(SRCS) illumos-gate
 
 FRC:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ To build there are three-ish steps
 	This will also ask for your password, so if you just run `make disk` and let
     dependencies take over, that won't go great.
 
-This is rough around the edges, particularly regarding `Makefile` dependencies
-and spurious rebuilds.  Please do fix this.
-
 Note that `make sysroot` and `make download-omnios` may be run multiple times
 as you work to keep those pieces up-to-date, the latter is especially useful
 as that goes into the disk image we create.

--- a/env/aarch64
+++ b/env/aarch64
@@ -107,19 +107,20 @@ export i386_PRIMARY_CCC=gcc10,$i386_GNUC_ROOT/bin/g++,gnu
 export i386_SHADOW_CCS=gcc7,$i386_GNUC_7_ROOT/bin/gcc,gnu
 export i386_SHADOW_CCCS=gcc7,$i386_GNUC_7_ROOT/bin/g++,gnu
 
-export aarch64_GNUC_ROOT=${CODEMGR_WS}/../cross/
+export aarch64_CROSS=${CODEMGR_WS}/../build/cross/
+export aarch64_GNUC_ROOT=${aarch64_CROSS}
 export aarch64_PRIMARY_CC=gcc10,$aarch64_GNUC_ROOT/bin/aarch64-unknown-solaris2.11-gcc,gnu
 export aarch64_PRIMARY_CCC=gcc10,$aarch64_GNUC_ROOT/bin/aarch64-unknown-solaris2.11-g++,gnu
 
-export aarch64_SYSROOT=${CODEMGR_WS}/../sysroot/
+export aarch64_SYSROOT=${CODEMGR_WS}/../build/sysroot/
 
 if [[ ${MACH} == "aarch64" ]]; then
 	export ADJUNCT_PROTO=${aarch64_SYSROOT}
-	export GLD=${CODEMGR_WS}/../cross/bin/aarch64-unknown-solaris2.11-ld
-	export OBJCOPY=${CODEMGR_WS}/../cross/bin/aarch64-unknown-solaris2.11-objcopy
-	export ANSI_CPP=${CODEMGR_WS}/../cross/bin/aarch64-unknown-solaris2.11-cpp
+	export GLD=${aarch64_CROSS}/bin/aarch64-unknown-solaris2.11-ld
+	export OBJCOPY=${aarch64_CROSS}/bin/aarch64-unknown-solaris2.11-objcopy
+	export ANSI_CPP=${aarch64_CROSS}/bin/aarch64-unknown-solaris2.11-cpp
 	export MKIMAGE=${CODEMGR_WS}/../build/u-boot/tools/mkimage
-	export DTC=${CODEMGR_WS}/../cross/bin/dtc
+	export DTC=${aarch64_CROSS}/bin/dtc
 fi
 
 # XXXARM: No cross, very broken
@@ -157,7 +158,7 @@ export PERL_PKGVERS=
 
 if [[ ${MACH} == "aarch64" ]]; then
 	export PERL_MACH=aarch64
-	export PERLDIR=${CODEMGR_WS}/../cross/usr/perl5/${PERL_VERSION}
+	export PERLDIR=${aarch64_CROSS}/usr/perl5/${PERL_VERSION}
 else
 	export PERL_VARIANT=-thread-multi
 fi

--- a/patches/u-boot.patch
+++ b/patches/u-boot.patch
@@ -1,0 +1,26 @@
+From b0e35e50d97630bd90795c5663b8dc02a65d40d8 Mon Sep 17 00:00:00 2001
+From: Hayashi Naoyuki <alpha@culzean.org>
+Date: Fri, 25 Feb 2022 12:57:22 +0900
+Subject: [PATCH] Add support for OpenSolaris on Raspberry Pi 4 Model B
+
+---
+ include/configs/rpi.h | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index 4c5c1ac31f..0a011c0fa4 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -174,7 +174,11 @@
+ 	ENV_DEVICE_SETTINGS \
+ 	ENV_DFU_SETTINGS \
+ 	ENV_MEM_LAYOUT_SETTINGS \
+-	BOOTENV
++	BOOTENV \
++	"enet_boot=setenv bootargs -D /scb/ethernet@7d580000 && dhcp ${kernel_addr_r} && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}\0" \
++	"mmc_boot=setenv bootargs -D /emmc2bus/mmc@7e340000 && fatload mmc 0 ${kernel_addr_r} inetboot && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}\0" \
++	"bootcmd=run mmc_boot\0"
+ 
++#define PHY_ANEG_TIMEOUT 20000
+ 
+ #endif

--- a/tools/build_qemu.sh
+++ b/tools/build_qemu.sh
@@ -1,0 +1,59 @@
+#!/bin/ksh93
+
+set -e
+
+DISK=$PWD/qemu-setup/illumos-disk.img
+POOL=armpool
+MNT=/mnt
+ROOTFS=ROOT/braich
+ROOT=$MNT/$ROOTFS
+DISKSIZE=8g
+
+if [[ ! -f Makefile || ! -d illumos-gate ]]; then
+	print -u2 "$0 should be run from the root of arm64-gate"
+	exit 2
+fi
+
+if [[ $(zonename) != global ]]; then
+	print -u2 "$0 should be run in the global zone"
+	exit 2
+fi
+
+mkdir -p $PWD/qemu-setup
+
+mkfile $DISKSIZE $DISK
+
+BASE_DEVICE=$(sudo lofiadm -la $DISK)
+RAW_DEVICE=${BASE_DEVICE/dsk/rdsk}
+SLICE=${BASE_DEVICE/p0/s0}
+
+# Taken from OmniOS kayak, note that this leaves s2 and s0 overlapping (which,
+# well...) and so requires zpool create -f, which I don't like.
+sudo fdisk -B $RAW_DEVICE
+# Create slice 0 covering all of the non-reserved space
+OIFS="$IFS"; IFS=" ="
+set -- $(sudo prtvtoc -f $RAW_DEVICE)
+IFS="$OIFS"
+# FREE_START=2048 FREE_SIZE=196608 FREE_COUNT=1 FREE_PART=...
+start=$2; size=$4
+sudo fmthard -d 0:2:01:$start:$size $RAW_DEVICE
+
+sudo zpool create -f -t $POOL -m $MNT $POOL $SLICE
+sudo zfs create -o canmount=noauto -o mountpoint=legacy $POOL/ROOT
+
+pv < out/illumos.zfs | sudo zfs receive -u $POOL/$ROOTFS
+sudo zfs set canmount=noauto $POOL/$ROOTFS
+sudo zfs set mountpoint=legacy $POOL/$ROOTFS
+
+sudo zfs create -V 1G $POOL/swap
+sudo zfs create -V 1G $POOL/dump
+
+sudo zpool set bootfs=$POOL/$ROOTFS $POOL
+sudo zpool set cachefile="" $POOL
+sudo zfs set mountpoint=none $POOL
+sudo zpool export $POOL
+sudo lofiadm -d $DISK
+
+cp illumos-gate/proto/root_aarch64/platform/QEMU,virt-4.1/inetboot.bin \
+    qemu-setup
+

--- a/tools/build_rpi4.sh
+++ b/tools/build_rpi4.sh
@@ -1,0 +1,137 @@
+#!/bin/ksh93
+
+DISK=$PWD/rpi4-setup/illumos-disk.img
+POOL=armpool
+MNT=/mnt
+ROOTFS=ROOT/braich
+ROOT=$MNT/$ROOTFS
+DISKSIZE=4g
+
+set -e
+
+if [[ ! -f Makefile || ! -d illumos-gate ]]; then
+	print -u2 "$0 should be run from the root of arm64-gate"
+	exit 2
+fi
+
+if [[ $(zonename) != global ]]; then
+	print -u2 "$0 should be run in the global zone"
+	exit 2
+fi
+
+# Populate the boot directory, which contains the files that should be copied
+# to the first (FAT) partition on the SD card.
+
+boot=$PWD/rpi4-setup/boot
+rm -rf $boot
+mkdir -p $boot
+
+cat <<EOM > $boot/config.txt
+gpu_mem=16
+start_file=start4cd.elf
+fixup_file=fixup4cd.dat
+arm_64bit=1
+enable_gic=1
+armstub=bl31.bin
+kernel=u-boot.bin
+dtoverlay=mmc
+dtoverlay=disable-wifi
+# The following two lines disable the mini UART and set the first PL011 UART as
+# the primary UART - that which is presented on GPIO14/GPIO15. The mini UART
+# is less capable and its baud rate is linked to the VCPU clock speed.
+enable_uart=1
+dtoverlay=disable-bt
+EOM
+
+cp illumos-gate/proto/root_aarch64/platform/RaspberryPi,4/inetboot $boot/
+
+cp build/arm-trusted-firmware/build/rpi4/debug/bl31.bin $boot/
+
+cp build/u-boot/u-boot.bin $boot/
+
+for f in \
+	COPYING.linux \
+	LICENCE.broadcom \
+	bootcode.bin \
+	fixup4cd.dat \
+	start4cd.elf \
+	bcm2711-rpi-4-b.dtb
+do
+	cp src/firmware-1.*/boot/$f $boot/
+done
+
+mkdir -p $boot/overlays
+cp src/firmware-1.*/boot/overlays/* $boot/overlays
+
+#
+#       -A id:act:bhead:bsect:bcyl:ehead:esect:ecyl:rsect:numsect
+
+mkfile $DISKSIZE $DISK
+
+BASE_DEVICE=$(sudo lofiadm -la $DISK)
+RAW_DEVICE=${BASE_DEVICE/dsk/rdsk}
+SLICE=${BASE_DEVICE/p0/s0}
+
+# Here's the partition table for one of the official raspberry Pi images.
+#
+# * Id    Act  Bhead  Bsect  Bcyl    Ehead  Esect  Ecyl    Rsect      Numsect
+#  12    0    0      1      64      3      32     1023    8192       524288
+#  131   0    3      32     1023    3      32     1023    532480     3309568
+#  0     0    0      0      0       0      0      0       0          0
+#  0     0    0      0      0       0      0      0       0          0
+
+FAT_SECTORS=524288
+RESV_SECTORS=8192
+
+# Create the required partition structure.
+sudo fdisk -B $RAW_DEVICE
+
+# Id Act Bhead Bsect Bcyl Ehead Esect Ecyl Rsect Numsect
+set -- $(sudo fdisk -W - $RAW_DEVICE | awk '$1 == 191 { print }')
+TOTAL_SECTORS=${10}
+
+((ZPOOL_SECTORS = TOTAL_SECTORS - FAT_SECTORS - RESV_SECTORS))
+
+#	id act bhead bsect bcyl ehead esect ecyl rsect numsect
+tf=`mktemp`
+# XXX come back and review this
+cat <<-EOM > $tf
+	12 0 0 1 64 3 32 1023 $RESV_SECTORS $FAT_SECTORS
+	191 128 3 32 1023 3 32 1023 532480 $ZPOOL_SECTORS
+EOM
+sudo fdisk -F $tf $RAW_DEVICE
+rm -f $tf
+
+# Format the FAT partition
+yes | sudo mkfs -F pcfs -o fat=32,b=bootfs $RAW_DEVICE:c
+sudo mount -F pcfs $BASE_DEVICE:c $MNT
+{ cd $boot; find . | sudo cpio -pmud $MNT 2>/dev/null || true; cd -; }
+sudo umount $MNT
+
+# Set up a VTOC in the second partition
+# Taken from OmniOS kayak, note that this leaves s2 and s0 overlapping (which,
+# well...) and so requires zpool create -f, which I don't like.
+# Create slice 0 covering all of the non-reserved space
+OIFS="$IFS"; IFS=" ="
+set -- $(sudo prtvtoc -f $RAW_DEVICE)
+IFS="$OIFS"
+# FREE_START=2048 FREE_SIZE=196608 FREE_COUNT=1 FREE_PART=...
+start=$2; size=$4
+sudo fmthard -d 0:2:01:$start:$size $RAW_DEVICE
+
+sudo zpool create -f -t $POOL -m $MNT -o autoexpand=on $POOL $SLICE
+sudo zfs create -o canmount=noauto -o mountpoint=legacy $POOL/ROOT
+
+pv < out/illumos.zfs | sudo zfs receive -u $POOL/$ROOTFS
+sudo zfs set canmount=noauto $POOL/$ROOTFS
+sudo zfs set mountpoint=legacy $POOL/$ROOTFS
+
+sudo zfs create -sV 1G $POOL/swap
+sudo zfs create -V 1G $POOL/dump
+
+sudo zpool set bootfs=$POOL/$ROOTFS $POOL
+sudo zpool set cachefile="" $POOL
+sudo zfs set mountpoint=none $POOL
+sudo zpool export $POOL
+sudo lofiadm -d $DISK
+


### PR DESCRIPTION
The first commit here restructures the Makefile and directory layout a bit, and resolves the problem that I was seeing with targets being spuriously rebuilt. Apart from illumos-gate, all of the directories that were previously extracted or checked out at the root of the project now end up under `src`, and `make clobber` completely resets by removing all of the external content. Dependencies seem to work - for example I wanted to rebuild u-boot to change the default boot option, and so did `rm stamps/u-boot*; make rpi4-disk` and it correctly rebuilt all of u-boot, u-boot-rpi4, illumos, zfs image, rpi4 disk image.

The second commit splits the qemu disk creation into two steps - creating a ZFS send stream, and using it to build a disk image. It then adds a new script to create a raspberry pi 4 image that can be written straight to an SD card and booted.
(There is a [known problem](https://illumos.topicbox.com/groups/arm/T9542351b66fcdadb-M89137403113d65df424e1358/illumos-for-aarch64-bootstrap-on-rpi4) that requires one to press return a few times during CPU startup), and some services currently fail, but it comes up.

```
root@braich:~# prtconf /devices
RaspberryPi,4
root@braich:~# psrinfo -pv
The physical processor has 4 virtual processors (0-3)
  AArch64 (midr 410fd083 revidr 00000000)
        ARM Cortex-A72 @ 1500 MHz
root@braich:~# prtconf -m
8128
root@braich:~# dladm
LINK        CLASS     MTU    STATE    BRIDGE     OVER
genet0      phys      1500   unknown  --         --
```
