### PR TITLE
Use the proper ROOT variable in pkg commands

### DIFF
--- a/tools/build_disk.sh
+++ b/tools/build_disk.sh
@@ -66,7 +66,7 @@ sudo pkg -R $ROOT install --no-refresh			\
      '*@latest'
 
 for publisher in omnios extra.omnios; do
-	sudo pkg -R $root set-publisher \
+	sudo pkg -R $ROOT set-publisher \
 	    -G file:///$PWD/archives/omnios \
 	    $publisher
 done


### PR DESCRIPTION
The $root variable is unset during disk creation, causing failure of the `make disk` step. Use the correct (uppercase) variable name.

With this change in place, `make disk` once again works.