### PR TITLE
Do a better job of boot archive construction / install fewer packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ all:
 
 SETUP_TARGETS =			\
 	arm-trusted-firmware	\
+	barn			\
 	binutils-gdb		\
 	boot-gcc		\
 	dtc			\
@@ -77,6 +78,7 @@ SYSROOT_PKGS=						\
 
 DOWNLOADS=			\
 	arm-trusted-firmware	\
+	barn			\
 	binutils-gdb		\
 	dtc			\
 	gcc			\
@@ -119,6 +121,10 @@ download-arm-trusted-firmware: $(SRCS)
 	  git clone --depth=1 --branch v2.9.0 \
 	      https://github.com/ARM-software/arm-trusted-firmware \
 	      $(SRCS)/arm-trusted-firmware
+
+download-barn: $(SRCS)
+	curl -fLo $(SRCS)/barn.c \
+	    https://github.com/omniosorg/kayak/raw/master/src/barn.c
 
 RPIFWVER=1.20230405
 download-rpi-firmware: $(ARCHIVES) $(SRCS)
@@ -313,6 +319,11 @@ $(STAMPS)/arm-trusted-firmware-stamp: $(STAMPS)/gcc-stamp $(STAMPS)/dtc-stamp
 	DTC=$(CROSS)/bin/dtc \
 	gmake -C $(BUILDS)/arm-trusted-firmware -j $(MAX_JOBS) \
 	    PLAT=rpi4 DEBUG=1 bl31 && \
+	touch $@
+
+barn: $(STAMPS)/barn-stamp
+$(STAMPS)/barn-stamp: $(SRCS)/barn.c
+	gcc -m64 -o $(BUILDS)/barn $(SRCS)/barn.c -lnvpair && \
 	touch $@
 
 dtc: $(STAMPS)/dtc-stamp

--- a/tools/build_image.sh
+++ b/tools/build_image.sh
@@ -30,10 +30,12 @@ pkgsend publish -s illumos-gate/packages/aarch64/nightly/repo.redist \
 # in the pkg database.
 export PKG_AUTOINSTALL=1
 
+ILLUMOS_REPO=$PWD/illumos-gate/packages/aarch64/nightly/repo.redist
+
 sudo pkg image-create --full						\
      --variant variant.arch=aarch64					\
      --set-property flush-content-cache-on-success=True			\
-     --publisher $PWD/illumos-gate/packages/aarch64/nightly/repo.redist	\
+     --publisher $ILLUMOS_REPO						\
      $ROOT
 
 for publisher in omnios extra.omnios; do
@@ -44,11 +46,27 @@ for publisher in omnios extra.omnios; do
 	     $publisher
 done
 
-# Install everything, to the degree that it is possible.
-sudo pkg -R $ROOT install --no-refresh			\
-     --reject=osnet					\
-     --reject=ssh-common				\
-     '*@latest'
+# We install entire, and also the optional packages listed in entire. These are
+# ones that we'd like in the initial image but can be removed by the user if
+# desired.
+# network/telnet is broken out here because unfortunately the unqualified name
+# is ambiguous (it also matches service/network/telnet). We can't just use
+# qualified names in general because the pkg://omnios/ packages conflict with
+# the newer versions in pkg://on-nightly/.
+pkglist=(
+	entire
+	"pkg://on-nightly/*"
+	developer/build-essential
+	$(pkg -R $ROOT contents -rH -a type=optional -o fmri entire | \
+	    cut -d/ -f4- | egrep -v 'telnet')
+	pkg://on-nightly/network/telnet
+)
+sudo pkg -R $ROOT install --reject ssh-common ${pkglist[*]}
+
+sudo pkg -R $ROOT set-publisher 			\
+    --non-sticky 					\
+    -G file:///$ILLUMOS_REPO 				\
+    on-nightly
 
 for publisher in omnios extra.omnios; do
 	sudo pkg -R $ROOT set-publisher			\


### PR DESCRIPTION
This PR does a better job of faking up the boot archive
so that the system does not perform an extra reboot on
first boot due to thinking the archive is stale.

Also, now that the number of packages in omnios-extra is growing
rapidly, this switches to just installing the mandatory and optional
packages which are listed as dependencies of 'entire'.

