### PR TITLE
Fix configuration of swap and dump in the images by default

### DIFF
--- a/tools/build_image.sh
+++ b/tools/build_image.sh
@@ -15,6 +15,7 @@ fi
 DATASET="$(zfs list -Ho name / | cut -d/ -f1)/braich_image"
 ROOT=/braich_image
 WORKDIR=$PWD
+POOL=armpool # We need to know this to configure swap and dump
 
 zfs list $DATASET >/dev/null 2>&1 && sudo zfs destroy -r $DATASET
 sudo zfs create -o mountpoint=$ROOT $DATASET

--- a/tools/build_qemu.sh
+++ b/tools/build_qemu.sh
@@ -3,7 +3,7 @@
 set -e
 
 DISK=$PWD/qemu-setup/illumos-disk.img
-POOL=armpool
+POOL=armpool			# Must match build_image
 MNT=/mnt
 ROOTFS=ROOT/braich
 ROOT=$MNT/$ROOTFS

--- a/tools/build_rpi4.sh
+++ b/tools/build_rpi4.sh
@@ -1,7 +1,7 @@
 #!/bin/ksh93
 
 DISK=$PWD/rpi4-setup/illumos-disk.img
-POOL=armpool
+POOL=armpool			# Must match build_image
 MNT=/mnt
 ROOTFS=ROOT/braich
 ROOT=$MNT/$ROOTFS


### PR DESCRIPTION
POOL became unset when image generation was refactored, so the default configurations became invalid.

@citrus-it @hadfl does this seem ok to you, is there a better way to do it?