### PR TITLE
Add a runner script for GICv3 systems

### DIFF
--- a/qemu-setup/run-gicv3.sh
+++ b/qemu-setup/run-gicv3.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+QEMU_SCRIPT_MACHINE="virt,gic-version=3" \
+  exec "${SHELL}" "${PWD}/run.sh"

--- a/qemu-setup/run.sh
+++ b/qemu-setup/run.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+QEMU_SCRIPT_MACHINE="${QEMU_SCRIPT_MACHINE:-virt-4.1}"
+QEMU_SCRIPT_MEMORY="${QEMU_SCRIPT_MEMORY:-6g}"
+QEMU_SCRIPT_NCPU="${QEMU_SCRIPT_NCPU:-2}"
+QEMU_SCRIPT_CPU="${QEMU_SCRIPT_CPU:-cortex-a53}"
+QEMU_SCRIPT_ACCEL="${QEMU_SCRIPT_ACCEL:-tcg,thread=multi}"
+
 vnic=braich0
 
 mac=`dladm show-vnic -p -o MACADDRESS $vnic | \
@@ -8,11 +14,11 @@ mac=`dladm show-vnic -p -o MACADDRESS $vnic | \
 
 exec qemu-system-aarch64 \
      -nographic \
-     -machine virt-4.1 \
-     -accel tcg,thread=multi \
-     -m 6g \
-     -smp cores=2 \
-     -cpu cortex-a53 \
+     -machine "${QEMU_SCRIPT_MACHINE}" \
+     -accel "${QEMU_SCRIPT_ACCEL}" \
+     -m ${QEMU_SCRIPT_MEMORY} \
+     -smp cores="${QEMU_SCRIPT_NCPU}" \
+     -cpu "${QEMU_SCRIPT_CPU}" \
      -kernel inetboot.bin \
      -append "-D /virtio_mmio@a003c00" \
      -netdev vnic,ifname=braich0,id=net0 \


### PR DESCRIPTION
Paramaterise a number of qemu arguments, with defaults set to the existing values. Add a wrapper script to override the machine for quickly testing GICv3 systems.

The following can be overridden:
* `-machine` via the `QEMU_SCRIPT_MACHINE` environment variable
* `-m` (memory) via the `QEMU_SCRIPT_MEMORY` environment variable
* `-smp` (SMP configuration) via the `QEMU_SCRIPT_NCPU` environment variable
* `-cpu` via the `QEMU_SCRIPT_CPU` environment variable
* `-accel` via the `QEMU_SCRIPT_ACCEL` environment variable

Testing:
* Inspecting command-line arguments for GICv2: https://gist.github.com/r1mikey/38fb6952afc0f921c1f1b46eba680a67
* Inspecting command-line arguments for GICv3: https://gist.github.com/r1mikey/cf33f007504bd37cb99a6e0a12c6b8a0
* Boot with GICv2: https://gist.github.com/r1mikey/76813fd8ba4c65d5d1777607abc0142c
* Boot with GICv3: https://gist.github.com/r1mikey/962d1d4d33ee401e0f100e059d1386f3