### PR TITLE
update to binutils 2.41

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ download-gcc: $(SRCS)
 	    https://github.com/richlowe/gcc $(SRCS)/gcc
 
 download-binutils-gdb: $(SRCS)
-	git clone --shallow-since=2019-01-01 -b illumos-arm64 \
+	git clone --shallow-since=2019-01-01 -b illumos-arm64-2-41 \
 	    https://github.com/richlowe/binutils-gdb $(SRCS)/binutils-gdb
 
 download-illumos-gate: FRC
@@ -176,6 +176,7 @@ $(STAMPS)/binutils-gdb-stamp: $(STAMPS)/sysroot-stamp
 	$(SRCS)/binutils-gdb/configure \
 	    --with-sysroot \
 	    --target=aarch64-unknown-solaris2.11 \
+	    --with-gmp-include="$(GMPINCDIR)" \
 	    --prefix=$(CROSS) \
 	    --enable-initfini-array && \
 	gmake -j $(MAX_JOBS) CPPFLAGS+='-I$(GMPINCDIR)' && \


### PR DESCRIPTION
This is not _really_ a flag day, but might become one if we use any newly added instructions or registers.

The change regarding GMP includes is unfortunate, but seems necessary.  I _think_ this will still work even if the gmp header is in the normal path, and not where we specify, though...