### PR TITLE
Explicitly use Python 3.11, 3.12 doesn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ SYSROOT_PKGS=						\
 	pkg:/system/library/dbus			\
 	pkg:/system/library/libdbus-glib		\
 	pkg:/system/library/mozilla-nss			\
-	pkg:/system/management/snmp/net-snmp
+	pkg:/system/management/snmp/net-snmp		\
+	pkg:/runtime/python-311
 
 DOWNLOADS=			\
 	arm-trusted-firmware	\

--- a/env/aarch64
+++ b/env/aarch64
@@ -173,7 +173,7 @@ export BUILDPERL32='#'
 #export PYTHON3_VERSION=3.5
 #export PYTHON3_PKGVERS=-35
 #export PYTHON3_SUFFIX=m
-for v in 3.9 3.10 3.11; do
+for v in 3.11 3.10 3.9; do
 	[ -x /usr/bin/python$v ] || continue
 	export PYTHON3_VERSION=$v
 	export PYTHON3_PKGVERS=-${v//./}


### PR DESCRIPTION
- Explicitly install python 3.11 into the sysroot, 3.12 will not work
- Search for python revisions in reverse order, so we find the newest first.

The 2nd change here should always be a good idea I think, the first is because Python 3.12 exposes bugs in pkgdepend(1) among other things.

@citrus-it @hadfl could you check this out and see if what I've done to work around this seems good for now?  Am I at risk of 3.11 disappearing underneath me? because I'm not actually sure how to all the 3.12 problems right now