### PR TITLE
rpi4: Update firmware components, enable SMC PCI support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,13 +116,15 @@ download-binutils-gdb: $(SRCS)
 download-illumos-gate: FRC
 	git clone -b arm64-gate https://github.com/richlowe/illumos-gate
 
+UBOOTVER=v2024.07
 download-u-boot: $(SRCS)
-	git clone --shallow-since=2019-01-01 -b v2023.01 \
+	git clone --shallow-since=2019-01-01 -b $(UBOOTVER) \
 	    https://github.com/u-boot/u-boot $(SRCS)/u-boot
 	cd $(SRCS)/u-boot && patch -p1 < $(PWD)/patches/u-boot.patch
 
+ARMFWVER=lts-v2.10.4
 download-arm-trusted-firmware: $(SRCS)
-	  git clone --depth=1 --branch v2.9.0 \
+	  git clone --depth=1 --branch $(ARMFWVER) \
 	      https://github.com/ARM-software/arm-trusted-firmware \
 	      $(SRCS)/arm-trusted-firmware
 
@@ -130,7 +132,7 @@ download-barn: $(SRCS)
 	curl -fLo $(SRCS)/barn.c \
 	    https://github.com/omniosorg/kayak/raw/master/src/barn.c
 
-RPIFWVER=1.20230405
+RPIFWVER=1.20240529
 download-rpi-firmware: $(ARCHIVES) $(SRCS)
 	wget -O $(ARCHIVES)/firmware-$(RPIFWVER).tar.gz \
 	    https://github.com/raspberrypi/firmware/archive/refs/tags/$(RPIFWVER).tar.gz
@@ -329,7 +331,7 @@ $(STAMPS)/arm-trusted-firmware-stamp: $(STAMPS)/gcc-stamp $(STAMPS)/dtc-stamp
 	CROSS_COMPILE=$(CROSS)/bin/aarch64-unknown-solaris2.11- \
 	DTC=$(CROSS)/bin/dtc \
 	gmake -C $(BUILDS)/arm-trusted-firmware -j $(MAX_JOBS) \
-	    PLAT=rpi4 DEBUG=1 bl31 && \
+	    PLAT=rpi4 DEBUG=1 SMC_PCI_SUPPORT=1 bl31 && \
 	touch $@
 
 barn: $(STAMPS)/barn-stamp

--- a/patches/u-boot.patch
+++ b/patches/u-boot.patch
@@ -1,17 +1,38 @@
+diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
+index 30228285..cc2303dd 100644
+--- a/board/raspberrypi/rpi/rpi.env
++++ b/board/raspberrypi/rpi/rpi.env
+@@ -75,3 +75,8 @@ fdt_addr_r=0x02600000
+ ramdisk_addr_r=0x02700000
+ 
+ boot_targets=mmc usb pxe dhcp
++
++enet_boot=setenv bootargs -D /scb/ethernet@7d580000 ${extra_bootargs} && dhcp ${kernel_addr_r} && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}
++mmc_boot=setenv bootargs -D /emmc2bus/mmc@7e340000 ${extra_bootargs} && fatload mmc 0 ${kernel_addr_r} inetboot && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}
++bootcmd=run mmc_boot
++
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index cd8fe8b518..e4ca4ee046 100644
+index 8e56bdc8..4938e54f 100644
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
-@@ -162,7 +162,11 @@
- 	ENV_DEVICE_SETTINGS \
- 	ENV_DFU_SETTINGS \
- 	ENV_MEM_LAYOUT_SETTINGS \
--	BOOTENV
-+	BOOTENV \
-+	"enet_boot=setenv bootargs -D /scb/ethernet@7d580000 ${extra_bootargs} && dhcp ${kernel_addr_r} && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}\0" \
-+	"mmc_boot=setenv bootargs -D /emmc2bus/mmc@7e340000 ${extra_bootargs} && fatload mmc 0 ${kernel_addr_r} inetboot && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}\0" \
-+	"bootcmd=run mmc_boot\0"
+@@ -31,4 +31,6 @@
+  */
+ #define CFG_SYS_SDRAM_SIZE		SZ_128M
  
 +#define PHY_ANEG_TIMEOUT 20000
- 
++
  #endif
+diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
+index 2851ebc9..4f3941be 100644
+--- a/board/raspberrypi/rpi/rpi.c
++++ b/board/raspberrypi/rpi/rpi.c
+@@ -327,9 +327,6 @@ static void set_fdtfile(void)
+  */
+ static void set_fdt_addr(void)
+ {
+-	if (env_get("fdt_addr"))
+-		return;
+-
+ 	if (fdt_magic(fw_dtb_pointer) != FDT_MAGIC)
+ 		return;
+ 


### PR DESCRIPTION

This updates all of the firmware components for the rpi4 image to:

```
Arm Trusted Firmware:        v2.10.4(debug)
Raspberry PI Firmware:       May 24 2024 15:30:16
Das U-Boot:                  2024.07
```

It also enables SMC PCI support in the Arm Trusted Firmware.

I've tested these components on an rpi4, but haven't yet booted an image
produced from this repository. I've put one at
https://downloads.omnios.org/media/braich/illumos-disk-test-rpi4.img.zst
and I'll get it tested in the next couple of days unless @hadfl gets to
it first.

