### PR TITLE
qemu: use u-boot here, too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ out/
 
 qemu-setup/illumos-disk.img
 qemu-setup/inetboot.bin
+qemu-setup/testsuite.log
+qemu-setup/u-boot.bin
 rpi4-setup/
-

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ SETUP_TARGETS =			\
 	sgs			\
 	sysroot			\
 	u-boot			\
-	u-boot-rpi4
+	u-boot-rpi4		\
+	u-boot-qemu
 
 SYSROOT_PUBLISHER=	omnios
 EXTRA_PUBLISHERS=	extra.omnios
@@ -317,10 +318,20 @@ $(STAMPS)/u-boot-stamp: $(STAMPS)/sysroot-stamp
 
 u-boot-rpi4: $(STAMPS)/u-boot-rpi4-stamp
 $(STAMPS)/u-boot-rpi4-stamp: $(STAMPS)/u-boot-stamp $(STAMPS)/gcc-stamp
-	gmake -C $(SRCS)/u-boot V=1 O=$(BUILDS)/u-boot \
+	mkdir -p $(BUILDS)/u-boot-rpi4
+	gmake -C $(SRCS)/u-boot V=1 O=$(BUILDS)/u-boot-rpi4 \
 	    $(U_BOOT_ARGS) \
 	    CROSS_COMPILE=$(CROSS)/bin/aarch64-unknown-solaris2.11- \
 	    ARCH=arm rpi_4_defconfig u-boot u-boot.bin && \
+	touch $@
+
+u-boot-qemu: $(STAMPS)/u-boot-qemu-stamp
+$(STAMPS)/u-boot-qemu-stamp: $(STAMPS)/u-boot-stamp $(STAMPS)/gcc-stamp
+	mkdir -p $(BUILDS)/u-boot-qemu
+	gmake -C $(SRCS)/u-boot V=1 O=$(BUILDS)/u-boot-qemu \
+	    $(U_BOOT_ARGS) \
+	    CROSS_COMPILE=$(CROSS)/bin/aarch64-unknown-solaris2.11- \
+	    ARCH=arm qemu_arm64_defconfig u-boot u-boot.bin && \
 	touch $@
 
 arm-trusted-firmware: $(STAMPS)/arm-trusted-firmware-stamp

--- a/qemu-setup/run.sh
+++ b/qemu-setup/run.sh
@@ -19,6 +19,7 @@ exec qemu-system-aarch64 \
      -m ${QEMU_SCRIPT_MEMORY} \
      -smp cores="${QEMU_SCRIPT_NCPU}" \
      -cpu "${QEMU_SCRIPT_CPU}" \
+     -bios u-boot.bin \
      -kernel inetboot.bin \
      -append "-D /virtio_mmio@a003c00" \
      -netdev vnic,ifname=braich0,id=net0 \

--- a/tools/build_qemu.sh
+++ b/tools/build_qemu.sh
@@ -82,4 +82,4 @@ sudo zpool export $POOL
 sudo lofiadm -d $DISK
 cp illumos-gate/proto/root_aarch64/platform/QEMU,virt-4.1/inetboot.bin \
     qemu-setup
-
+cp build/u-boot-qemu/u-boot.bin qemu-setup

--- a/tools/build_rpi4.sh
+++ b/tools/build_rpi4.sh
@@ -66,7 +66,7 @@ cp illumos-gate/proto/root_aarch64/platform/RaspberryPi,4/inetboot $boot/
 
 cp build/arm-trusted-firmware/build/rpi4/debug/bl31.bin $boot/
 
-cp build/u-boot/u-boot.bin $boot/
+cp build/u-boot-rpi4/u-boot.bin $boot/
 
 for f in \
 	COPYING.linux \


### PR DESCRIPTION
There's a couple of reasons to do this, but I think they end up basically the same.

1) It means all the boards boot the same way (a reasonable thing to expect to
   continue on systems that aren't UEFI).
2) Most actual hardware requires some level of firmware initialization,
   without firmware on qemu, that initialization never happens and the OS has
   to take care of it.  It would be nice if that were possible, but it's a lot
   of work that's not really ARM-specific

This doesn't use arm-trusted-firmware as well since that is for the moment less relevant and being an "insecure" CPU world is perhaps an interesting quirk to preserve.