### PR TITLE
env: detect OmniOS correctly even if we're running different illumos bits

### DIFF
--- a/env/aarch64
+++ b/env/aarch64
@@ -185,7 +185,7 @@ export BUILDVERSION_EXEC="git describe --all --long --dirty"
 
 # Only OmniOS has a fixed pkgdepend right now, and only bloody dated after
 # April 2023
-if [[ ! -f /etc/versions/build.illumos-omnios ]]; then
+if [[ $(awk -F= '$1 == "NAME" { print $2 }' /etc/os-release) != '"OmniOS"' ]]; then
 	export SUPPRESSPKGDEP=true
 else
 	awk -F= '$1 == "BUILD_ID" { gsub("\\.", " ", $2); print $2 }'  \


### PR DESCRIPTION
My original code here assuming `/etc/verions/build.illumos-omnios` would exist on OmniOS, except it doesn't if you're running other illumos bits.  Pull it out of `/etc/os-release` too to check.

This should stop us supressing packaging dependencies on onu'd OmniOS, and then failing to run tests (etc) because `sudo` isn't installed.