### PR TITLE
update miniperl to 5.40.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ DOWNLOADS=			\
 	rpi-firmware		\
 	u-boot
 
-PERLVER=5.38.0
-PERLCROSSVER=1.5
+PERLVER=5.40.0
+PERLCROSSVER=1.6
 PERLMAJVER.cmd= echo $(PERLVER) | cut -d. -f1,2
 PERLMAJVER= $(PERLMAJVER.cmd:sh)
 download-perl: $(ARCHIVES) $(SRCS)

--- a/env/aarch64
+++ b/env/aarch64
@@ -141,7 +141,7 @@ PKGVERS_BRANCH=999999.$(date +%Y.%-m.%-e.%-H.%-M);	export PKGVERS_BRANCH
 # contains your new defaults OR your .env file sets them.
 # These are how you would override for building on OmniOS r151028, for
 # example.
-export PERL_VERSION=5.38
+export PERL_VERSION=5.40
 export PERL_PKGVERS=
 
 if [[ ${MACH} == "aarch64" ]]; then


### PR DESCRIPTION
This updates miniperl to 5.40.0.

I have a full OmniOS braich build ready with perl 5.40.0 which I can publish once this lands so `make download-omnios` will get the correct bits.