### PR TITLE
u-boot and dtc updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ download-binutils-gdb: $(SRCS)
 download-illumos-gate: FRC
 	git clone -b arm64-gate https://github.com/richlowe/illumos-gate
 
-UBOOTVER=v2024.07
+UBOOTVER=v2024.10
 download-u-boot: $(SRCS)
 	git clone --shallow-since=2019-01-01 -b $(UBOOTVER) \
 	    https://github.com/u-boot/u-boot $(SRCS)/u-boot
@@ -304,7 +304,8 @@ $(STAMPS)/perl-stamp: $(STAMPS)/gcc-stamp
 U_BOOT_ARGS =							\
 	HOSTCC="gcc -m64"					\
 	HOSTCFLAGS="-I/opt/ooce/include"			\
-	HOSTLDLIBS="-L/opt/ooce/lib/amd64 -lnsl -lsocket"
+	HOSTLDLIBS="-L/opt/ooce/lib/amd64 -lnsl -lsocket"	\
+	NO_PYTHON=1
 
 u-boot: $(STAMPS)/u-boot-stamp
 $(STAMPS)/u-boot-stamp: $(STAMPS)/sysroot-stamp

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ download-rpi-firmware: $(ARCHIVES) $(SRCS)
 
 # XXXARM: We specify what we extract, because the release tarball contains a
 # GNU tar-ism we don't understand.
-DTCVER=1.6.1
+DTCVER=1.7.1
 download-dtc: $(ARCHIVES)
 	wget -O $(ARCHIVES)/dtc-$(DTCVER).tar.gz \
 	    https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/dtc-$(DTCVER).tar.gz


### PR DESCRIPTION
I verified that `arm-trusted-firmware` and `illumos-gate` can still be built with the updated `dtc` and successfully booted an image containing the updated `u-boot` on the rpi 4.