### PR TITLE
fix dependency resolution in January/February

### DIFF
--- a/env/aarch64
+++ b/env/aarch64
@@ -201,7 +201,7 @@ else
 	# of OmniOS that supports cross-pkgdepend in this world, and we need to
 	# set the appropriate environment variable.
 	if (( PYTHON3_MINOR >= 12 &&
-	    (major < 151049 || year < 2024 || month < 3) )); then
+	    (major < 151049 || ((${year}${month} < 202403))) )); then
 		export SUPPRESSPKGDEP=true
 	else
 		if [[ ${MACH} != ${NATIVE_MACH} ]]; then


### PR DESCRIPTION
We currently end up w/o  resolved dependencies for illumos packages:
```
root@braich:~# pkg contents -m system/library | grep ^depend
depend fmri=system/library/python/solaris-312 predicate=runtime/python-312 type=conditional
depend fmri=system/library/storage/scsi-plugins type=require
depend fmri=consolidation/osnet/osnet-incorporation type=require
```

With this fix in place, it looks better:
```
$ pkg -R build/sysroot/ contents -m -g illumos-gate/packages/aarch64/nightly/repo.redist/ system/library | grep ^depend
depend fmri=system/library/python/solaris-312 predicate=runtime/python-312 type=conditional
depend fmri=consolidation/osnet/osnet-incorporation type=require
depend fmri=pkg:/SUNWcs@0.5.11-999999.2025.1.10.12.56 type=require
depend fmri=pkg:/library/libtecla@1.6.0-999999.2025.1.10.12.56 type=require
depend fmri=pkg:/library/libxml2@2.13.5-151053.0 type=require
depend fmri=pkg:/library/nspr@4.36-151053.0 type=require
depend fmri=pkg:/library/security/openssl-3@3.4.0-151053.0 type=require
depend fmri=pkg:/library/zlib@1.3.1-151053.0 type=require
depend fmri=pkg:/service/resource-pools@0.5.11-999999.2025.1.10.12.56 type=require
depend fmri=pkg:/system/library/math@0.5.11-999999.2025.1.10.12.56 type=require
depend fmri=pkg:/system/library/mozilla-nss@3.107-151053.0 type=require
depend fmri=pkg:/system/library/security/gss@0.5.11-999999.2025.1.10.12.56 type=require
depend fmri=pkg:/system/library/security/libsasl@0.5.11-999999.2025.1.10.12.56 type=require
depend fmri=pkg:/system/network/overlay@0.5.11-999999.2025.1.10.12.56 type=require
depend fmri=system/library/storage/scsi-plugins type=require
```