### PR TITLE
more recent rpi4 could benefit from a speed boost

### DIFF
--- a/tools/build_rpi4.sh
+++ b/tools/build_rpi4.sh
@@ -46,6 +46,7 @@ rm -rf $boot
 mkdir -p $boot
 
 cat <<EOM > $boot/config.txt
+arm_boost=1
 gpu_mem=16
 start_file=start4cd.elf
 fixup_file=fixup4cd.dat


### PR DESCRIPTION
This increases the maximum frequency that can be set for the CPU from 1500 MHz to 1800 MHz on more recent RPI4 that support it. It's a no-op on earlier RPI4 devices. Apparently it's not on by default for "compatibility" reasons with older devices, so all have the same maximum CPU frequency by default.