### PR TITLE
build: Support new inetboot locations

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -15,4 +15,4 @@ end
 
 
 file illumos-gate/usr/src/psm/stand/boot/aarch64/virt/inetboot.out
-file illumos-gate/proto/root_aarch64/platform/QEMU,virt/kernel/aarch64/unix
+file illumos-gate/proto/root_aarch64/platform/linux,dummy-virt/kernel/aarch64/unix

--- a/tools/build_qemu.sh
+++ b/tools/build_qemu.sh
@@ -80,6 +80,8 @@ sudo zfs set mountpoint=none $POOL
 sudo zpool export $POOL
 
 sudo lofiadm -d $DISK
-cp illumos-gate/proto/root_aarch64/platform/QEMU,virt/inetboot.bin \
-    qemu-setup
-
+INETBOOT="illumos-gate/proto/root_aarch64/platform/linux,dummy-virt/inetboot.bin"
+if [ ! -f "${INETBOOT}" ]; then
+	INETBOOT="illumos-gate/proto/root_aarch64/platform/QEMU,virt/inetboot.bin"
+fi
+cp "${INETBOOT}" qemu-setup/

--- a/tools/build_rpi4.sh
+++ b/tools/build_rpi4.sh
@@ -63,7 +63,11 @@ enable_uart=1
 dtoverlay=disable-bt
 EOM
 
-cp illumos-gate/proto/root_aarch64/platform/RaspberryPi,4/inetboot $boot/
+INETBOOT="illumos-gate/proto/root_aarch64/platform/raspberrypi,4-model-b/inetboot"
+if [ ! -f "${INETBOOT}" ]; then
+	INETBOOT="illumos-gate/proto/root_aarch64/platform/RaspberryPi,4/inetboot"
+fi
+cp "${INETBOOT}" $boot/
 
 cp build/arm-trusted-firmware/build/rpi4/debug/bl31.bin $boot/
 


### PR DESCRIPTION
With that `platmod`-isation of `armv8` the inetboot locations have changed. While there's a compatability symlink in place we prefer the new location in the assembly scripts, which allows us to land the `unix` changes and give folks some time to move their build tree over.

This supports https://github.com/richlowe/illumos-gate/pull/126.