### PR TITLE
build: Switch to loader(7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,10 +378,10 @@ $(PWD)/out/illumos.zfs: $(STAMPS)/illumos-stamp
 	ksh tools/build_image.sh
 
 qemu-disk: $(PWD)/out/illumos.zfs
-	ksh tools/build_qemu.sh --efi
+	ksh tools/build_qemu.sh
 
 rpi4-disk: $(PWD)/out/illumos.zfs
-	ksh tools/build_rpi4.sh --efi
+	ksh tools/build_rpi4.sh
 
 disk: qemu-disk rpi4-disk
 

--- a/env/aarch64
+++ b/env/aarch64
@@ -120,6 +120,7 @@ if [[ ${MACH} == "aarch64" ]]; then
 	export ADJUNCT_PROTO=${aarch64_SYSROOT}
 	export GLD=${aarch64_CROSS}/bin/$triple-ld
 	export OBJCOPY=${aarch64_CROSS}/bin/$triple-objcopy
+	export OBJDUMP=${aarch64_CROSS}/bin/$triple-objdump
 	export ANSI_CPP=${aarch64_CROSS}/bin/$triple-cpp
 	export MKIMAGE=${CODEMGR_WS}/../build/u-boot/tools/mkimage
 	export DTC=${aarch64_CROSS}/bin/dtc

--- a/patches/u-boot.patch
+++ b/patches/u-boot.patch
@@ -1,32 +1,8 @@
-diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
-index 30228285..cc2303dd 100644
---- a/board/raspberrypi/rpi/rpi.env
-+++ b/board/raspberrypi/rpi/rpi.env
-@@ -75,3 +75,8 @@ fdt_addr_r=0x02600000
- ramdisk_addr_r=0x02700000
- 
- boot_targets=mmc usb pxe dhcp
-+
-+enet_boot=setenv bootargs -D /scb/ethernet@7d580000 ${extra_bootargs} && dhcp ${kernel_addr_r} && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}
-+mmc_boot=setenv bootargs -D /emmc2bus/mmc@7e340000 ${extra_bootargs} && fatload mmc 0 ${kernel_addr_r} inetboot && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}
-+bootcmd=run mmc_boot
-+
-diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 8e56bdc8..4938e54f 100644
---- a/include/configs/rpi.h
-+++ b/include/configs/rpi.h
-@@ -31,4 +31,6 @@
-  */
- #define CFG_SYS_SDRAM_SIZE		SZ_128M
- 
-+#define PHY_ANEG_TIMEOUT 20000
-+
- #endif
 diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
-index 2851ebc9..4f3941be 100644
+index 18be244aa7..c9aa8fb86f 100644
 --- a/board/raspberrypi/rpi/rpi.c
 +++ b/board/raspberrypi/rpi/rpi.c
-@@ -327,9 +327,6 @@ static void set_fdtfile(void)
+@@ -344,9 +344,6 @@ static void set_fdtfile(void)
   */
  static void set_fdt_addr(void)
  {
@@ -36,3 +12,52 @@ index 2851ebc9..4f3941be 100644
  	if (fdt_magic(fw_dtb_pointer) != FDT_MAGIC)
  		return;
  
+diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
+index 30228285ed..016f6d3869 100644
+--- a/board/raspberrypi/rpi/rpi.env
++++ b/board/raspberrypi/rpi/rpi.env
+@@ -75,3 +75,9 @@ fdt_addr_r=0x02600000
+ ramdisk_addr_r=0x02700000
+ 
+ boot_targets=mmc usb pxe dhcp
++
++enet_boot=setenv bootargs -D /scb/ethernet@7d580000 ${extra_bootargs} && dhcp ${kernel_addr_r} && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}
++mmc_boot=setenv bootargs -D /emmc2bus/mmc@7e340000 ${extra_bootargs} && fatload mmc 0 ${kernel_addr_r} inetboot && fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && bootm ${kernel_addr_r} - ${fdt_addr_r}
++efi_mmc_boot=fdt addr ${fdt_addr} && fdt move ${fdt_addr} ${fdt_addr_r} 0x10000 && load mmc 0:1 ${kernel_addr_r} EFI/BOOT/bootaa64.efi && bootefi ${kernel_addr_r} ${fdt_addr_r}
++bootcmd=run efi_mmc_boot
++
+diff --git a/drivers/video/bcm2835.c b/drivers/video/bcm2835.c
+index 0c81e60662..960ecc5ed5 100644
+--- a/drivers/video/bcm2835.c
++++ b/drivers/video/bcm2835.c
+@@ -24,7 +24,7 @@ static int bcm2835_video_probe(struct udevice *dev)
+ 		return -EIO;
+ 
+ 	debug("bcm2835: Setting up display for %d x %d\n", w, h);
+-	ret = bcm2835_set_video_params(&w, &h, 32, BCM2835_MBOX_PIXEL_ORDER_RGB,
++	ret = bcm2835_set_video_params(&w, &h, 32, BCM2835_MBOX_PIXEL_ORDER_BGR,
+ 				       BCM2835_MBOX_ALPHA_MODE_IGNORED,
+ 				       &fb_base, &fb_size, &pitch);
+ 	if (ret)
+@@ -37,8 +37,8 @@ static int bcm2835_video_probe(struct udevice *dev)
+ 	fb_end = fb_base + fb_size;
+ 	fb_end = ALIGN(fb_end, 1 << MMU_SECTION_SHIFT);
+ 	mmu_set_region_dcache_behaviour(fb_start, fb_end - fb_start,
+-					DCACHE_WRITEBACK);
+-	video_set_flush_dcache(dev, true);
++					2 << 2);
++	video_set_flush_dcache(dev, false);
+ 
+ 	bpp = pitch / w;
+ 	switch (bpp) {
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index 8e56bdc84a..4938e54f6e 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -31,4 +31,6 @@
+  */
+ #define CFG_SYS_SDRAM_SIZE		SZ_128M
+ 
++#define PHY_ANEG_TIMEOUT 20000
++
+ #endif

--- a/qemu-setup/run.sh
+++ b/qemu-setup/run.sh
@@ -20,8 +20,6 @@ exec qemu-system-aarch64 \
      -smp cores="${QEMU_SCRIPT_NCPU}" \
      -cpu "${QEMU_SCRIPT_CPU}" \
      -bios u-boot.bin \
-     -kernel inetboot.bin \
-     -append "-D /virtio_mmio@a003c00" \
      -netdev vnic,ifname=braich0,id=net0 \
      -device virtio-net-device,netdev=net0,mac=${mac} \
      -device virtio-blk-device,drive=hd0 \

--- a/tools/build_image.sh
+++ b/tools/build_image.sh
@@ -175,6 +175,13 @@ rm -f $SVCCFG_REPOSITORY
 	sudo touch ./boot/solaris/timestamp.cache
 )
 
+# drop a boot config override into the loader configs to allow booting
+# from an implementation architecture and to prefer the serial console
+echo 'bootfile="/platform/${IMPLARCH}/kernel/${ISADIR}/unix;/platform/${BASEARCH}/kernel/${ISADIR}/unix"' | \
+    sudo tee $ROOT/boot/conf.d/00-aarch64-defaults.conf >/dev/null
+echo 'console="${default-uart-name},text"' | \
+    sudo tee -a $ROOT/boot/conf.d/00-aarch64-defaults.conf >/dev/null
+
 sudo zfs snapshot $DATASET@image
 mkdir -p out
 sudo zfs send $DATASET@image | pv > out/illumos.zfs

--- a/tools/build_rpi4.sh
+++ b/tools/build_rpi4.sh
@@ -6,23 +6,21 @@ MNT=/mnt
 ROOTFS=ROOT/braich
 ROOT=$MNT/$ROOTFS
 DISKSIZE=4g
+BE_UUID=`/usr/bin/uuidgen`
 
 USAGE="[+NAME?build_rpi4 --- create a disk image for a Raspberry Pi 4]"
-USAGE+="[e:efi?Generate an EFI disk image]"
-USAGE+="[m:mbr?Generate an MBR disk image]"
 
-typeset -i EFI=0
 typeset -i MBR=0
 
 while getopts "$USAGE" opt; do
 	case $opt in
-	    e)	EFI=1 ;;
+	    e)	;;
 	    m)	MBR=1 ;;
 	esac
 done
 
-if ((EFI + MBR != 1)); then
-	print -u2 "$0: Exactly one of --mbr or --efi must be provided"
+if ((MBR != 0)); then
+	print -u2 "$0: The --mbr argument is no longer supported"
 	exit 2
 fi
 
@@ -30,6 +28,16 @@ set -e
 
 if [[ ! -f Makefile || ! -d illumos-gate ]]; then
 	print -u2 "$0 should be run from the root of arm64-gate"
+	exit 2
+fi
+
+if [ ! -f $PWD/illumos-gate/proto/root_aarch64/boot/loader64.efi ]; then
+	print -u2 "loader64.efi not found in proto area"
+	exit 2
+fi
+
+if [ ! -f $PWD/build/u-boot-rpi4/u-boot.bin ]; then
+	print -u2 "u-boot-rpi4/u-boot.bin not found in build area"
 	exit 2
 fi
 
@@ -63,8 +71,6 @@ enable_uart=1
 dtoverlay=disable-bt
 EOM
 
-cp illumos-gate/proto/root_aarch64/platform/RaspberryPi,4/inetboot $boot/
-
 cp build/arm-trusted-firmware/build/rpi4/debug/bl31.bin $boot/
 
 cp build/u-boot-rpi4/u-boot.bin $boot/
@@ -83,79 +89,24 @@ done
 mkdir -p $boot/overlays
 cp src/firmware-1.20*/boot/overlays/* $boot/overlays
 
+mkdir -p $boot/EFI/BOOT
+cp $PWD/illumos-gate/proto/root_aarch64/boot/loader64.efi \
+    $boot/EFI/BOOT/bootaa64.efi
+
 mkfile $DISKSIZE $DISK
 BLK_DEVICE=$(sudo lofiadm -la $DISK)
 RAW_DEVICE=${BLK_DEVICE/dsk/rdsk}
 
-if ((EFI)); then
-	print "Building an EFI (GPT-partitioned) image"
+print "Building a GPT-partitioned image"
 
-	# This is the easier option, we can just use the -B option to zpool
-	# to get it to create an initial FAT partition for us.
-	sudo zpool create \
-	    -B -o bootsize=256M \
-	    -t $POOL -m $MNT $POOL ${BLK_DEVICE%p0}
+# This is the easier option, we can just use the -B option to zpool
+# to get it to create an initial FAT partition for us.
+sudo zpool create \
+    -B -o bootsize=256M \
+    -t $POOL -m $MNT $POOL ${BLK_DEVICE%p0}
 
-	FAT_RAW=${RAW_DEVICE/p0/s0}
-	FAT_BLK=${BLK_DEVICE/p0/s0}
-else
-	print "Building an MBR-partitioned image"
-
-	# Here's the partition table for one of the official Raspberry Pi
-	# Linux images.
-	#
-	#  Id  Act Bhead  Bsect Bcyl Ehead Esect Ecyl Rsect  Numsect
-	#  12  0   0      1     64   3     32    1023 8192   524288
-	#  131 0   3      32    1023 3     32    1023 532480 3309568
-	#  0   0   0      0     0    0     0     0    0      0
-	#  0   0   0      0     0    0     0     0    0      0
-
-	# XXX - work out what to use here.
-	# These values do produce bootable images.
-	FAT_SECTORS=524288	# Ends up being ~256MiB
-	RESV_FAT_SECTORS=8192
-	RESV_SOL_SECTORS=532480
-
-	# Create the required partition structure.
-	# Calculate the total number of available sectors by creating a single
-	# sol2 partition that spans the entire disk and reading the Numsect
-	# value back out.
-	#
-	sudo fdisk -B $RAW_DEVICE
-	# Id Act Bhead Bsect Bcyl Ehead Esect Ecyl Rsect Numsect
-	set -- $(sudo fdisk -W - $RAW_DEVICE | awk '$1 == 191 { print }')
-	TOTAL_SECTORS=${10}
-
-	# Now create the real partition table, small FAT32 partition followed
-	# by a solaris one filling the remaining space.
-
-	((ZPOOL_SECTORS = TOTAL_SECTORS - FAT_SECTORS - RESV_FAT_SECTORS))
-
-	#	id act bhead bsect bcyl ehead esect ecyl rsect numsect
-	tf=`mktemp`
-	cat <<-EOM > $tf
-		12 0 0 1 64 3 32 1023 $RESV_FAT_SECTORS $FAT_SECTORS
-		191 128 3 32 1023 3 32 1023 $RESV_SOL_SECTORS $ZPOOL_SECTORS
-	EOM
-	sudo fdisk -F $tf $RAW_DEVICE
-	rm -f $tf
-
-	# Set up a VTOC in the second partition Taken from OmniOS kayak, note
-	# that this leaves s2 and s0 overlapping (which, well...) and so
-	# requires zpool create -f, which I don't like.
-	# Create slice 0 covering all of the non-reserved space
-	OIFS="$IFS"; IFS=" ="
-	set -- $(sudo prtvtoc -f $RAW_DEVICE)
-	IFS="$OIFS"
-	# FREE_START=2048 FREE_SIZE=196608 FREE_COUNT=1 FREE_PART=...
-	start=$2; size=$4
-	sudo fmthard -d 0:2:01:$start:$size $RAW_DEVICE
-
-	sudo zpool create -f -t $POOL -m $MNT $POOL $SLICE ${BLK_DEVICE/p0/s0}
-
-	FAT_RAW=$RAW_DEVICE:c
-	FAT_BLK=$BLK_DEVICE:c
-fi
+FAT_RAW=${RAW_DEVICE/p0/s0}
+FAT_BLK=${BLK_DEVICE/p0/s0}
 
 print "Populating root"
 
@@ -164,13 +115,16 @@ sudo zfs create -o canmount=noauto -o mountpoint=legacy $POOL/ROOT
 pv < out/illumos.zfs | sudo zfs receive -u $POOL/$ROOTFS
 sudo zfs set canmount=noauto $POOL/$ROOTFS
 sudo zfs set mountpoint=legacy $POOL/$ROOTFS
+sudo zfs set org.opensolaris.libbe:uuid=$BE_UUID $POOL/$ROOTFS
+sudo zfs set org.opensolaris.libbe:policy=static $POOL/$ROOTFS
 
 sudo zfs create -sV 1G $POOL/swap
 sudo zfs create -V 1G $POOL/dump
 
 sudo zpool set bootfs=$POOL/$ROOTFS $POOL
 sudo zpool set cachefile="" $POOL
-sudo zfs set mountpoint=none $POOL
+sudo zfs set canmount=noauto $POOL
+sudo zfs set mountpoint=/$POOL $POOL
 sudo zpool export $POOL
 
 print "Populating boot"


### PR DESCRIPTION
**NOTE**: This PR is required by https://github.com/richlowe/illumos-gate/pull/144 and makes no sense without that PR.

Add support for building the `loader(7)` changes in https://github.com/richlowe/illumos-gate/pull/144 - this breaks down as:
* Override `OBJDUMP` to point to our cross tools
* Patch U-Boot for rpi4 to configure the framebuffer per later U-Boot expectations (without this, red and blue are swapped)
* Patch U-Boot to use an unordered mapping (getting merging as a property) for the rpi4 framebuffer. This dramatically improves framebuffer write performance.
* Tweak the qemu run script to no longer specify `inetboot` or pass the root device path.
* Tweak the build_image script to drop in a small override file that sets the kernel path to a list of kernels and prefers the UART console.
* Remove MBR support from the qemu image building script (this is not supported by installboot) and make the script add the properties needed for libbe to work.
* Remove MBR support from the rpi4 image building script (this is not supported by installboot) and make the script add the properties needed for libbe to work.

This all represents a very big flag day. To update your build environment after pulling this change (and when switching back to the main branch), do:
```
rm -rf src/u-boot build/u-boot build/u-boot-qemu build/u-boot-rpi4 \
   stamps/u-boot-stamp stamps/u-boot-qemu-stamp stamps/u-boot-rpi4-stamp
make download-u-boot
make u-boot u-boot-qemu u-boot-rpi4
```