### PR TITLE
arm64-gate: switch to using a cpio boot archive

### DIFF
--- a/tools/build_image.sh
+++ b/tools/build_image.sh
@@ -132,42 +132,24 @@ sudo chown root:sys $ROOT/etc/svc/repository.db
 sudo chmod 0600 $ROOT/etc/svc/repository.db
 rm -f $SVCCFG_REPOSITORY
 
-# If this worked it would be lovely, but it doesn't yet
-# because it can only create ufs/cpio archives, and we can only boot from hsfs
-#sudo illumos-gate/usr/src/cmd/boot/scripts/create_ramdisk -R $ROOT -p aarch64 -f ufs-nocompress
-
-# However, the native tools do not yet know how to build a boot archive for
-# aarch64. Create a boot archive manually, faking up enough so that the system
-# is happy with the boot archive on first boot.
+sudo mkdir $ROOT/platform/armv8/aarch64  # won't exist yet
+sudo $ROOT/boot/solaris/bin/create_ramdisk -R $ROOT -p aarch64 -f cpio
+# Expand the filelist that was used to create our boot archive into a format
+# suitable for use as the archive cache and as input to stat cache production.
 (
-	cd $ROOT
-
-	typeset filelist=$(mktemp)
-
-	./boot/solaris/bin/extract_boot_filelist \
-	    -R $ROOT -p aarch64 boot/solaris/filelist.ramdisk | \
-	    while read file; do
-		[ -e "$file" ] && find "$file" -type f
-	done | awk '{printf("/%s=./%s\n", $1, $1)}' > $filelist
-
-	sudo mkdir -p ./platform/armv8/aarch64
-	sudo mkisofs \
-	    -quiet \
-	    -graft-points \
-	    -dlrDJN \
-	    -relaxed-filenames \
-	    -o ./platform/armv8/aarch64/boot_archive \
-	    -path-list $filelist
-
-	sudo $WORKDIR/build/barn -R $ROOT -w $filelist
-
-	/usr/bin/sed -i 's/=\./=/' $filelist
-	sudo cp $filelist ./platform/armv8/aarch64/archive_cache
-	sudo chmod 644 ./platform/armv8/aarch64/archive_cache
-	rm -f $filelist
-
-	sudo touch ./boot/solaris/timestamp.cache
+    cd $ROOT
+    $ROOT/boot/solaris/bin/extract_boot_filelist \
+        -R $ROOT -p aarch64 boot/solaris/filelist.ramdisk \
+        etc/boot/solaris/filelist.ramdisk \
+        | while read file; do
+            [ -e "$file" ] && find "$file" -type f
+        done | awk '{printf("/%s=%s\n", $1, $1)}' | \
+    sudo tee platform/armv8/aarch64/archive_cache > /dev/null 2>&1
+    sudo chmod 644 platform/armv8/aarch64/archive_cache
 )
+# Now create the stat cache.
+sudo $WORKDIR/build/barn -R $ROOT -w $ROOT/platform/armv8/aarch64/archive_cache
+sudo touch $ROOT/boot/solaris/timestamp.cache
 
 # drop a boot config override into the loader configs to allow booting from an
 # implementation architecture, to prefer the serial console, and to boot


### PR DESCRIPTION
Now that https://github.com/richlowe/illumos-gate/pull/185 is merged we can consider switching our default boot_archive to cpio (from hsfs).

This change switches the default format to cpio while retaining `barn` invocation (recording file attributes) to avoid am unnecessary forced reboot during first boot.

Tested by booting with a freshly built illumos to ensure that no unintended reboot occurs, ensuring that this on-disk file is gzipped (the archive is compressed), rebooting to observe the first-reboot rebuild logic and observing no further need for rebuilds.

Testing output: https://gist.github.com/r1mikey/ce59f5ef8dfcbb2ad822bf09c3306118